### PR TITLE
add endpoint signUp in frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -8,8 +8,10 @@ import twitter from "../assets/twitter.png";
 import gmail from "../assets/gmail.png";
 import { Link } from "react-router-dom";
 import Logo from "../components/Logo";
+import authAPI from "../services/authAPI";
 
 export default function HomePage() {
+  const handleSignIn = () => {};
   return (
     <div className="HomePage">
       <section>
@@ -28,7 +30,9 @@ export default function HomePage() {
               <label htmlFor="">Password:</label>
               <input type="password" placeholder="enter password" />
 
-              <button className="btn-accent mt-12">Login</button>
+              <button className="btn-accent mt-12" onClick={handleSignIn()}>
+                Login
+              </button>
             </form>
             <Link to="/register">
               <button className="btn-white">Register</button>

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import circles from "../assets/3circles.svg";
 import checklist from "../assets/checklist.svg";
 import Logo from "../components/Logo";
@@ -8,14 +8,49 @@ import fb from "../assets/fb.png";
 import twitter from "../assets/twitter.png";
 import gmail from "../assets/gmail.png";
 
+import authAPI from "../services/authAPI";
+
 export default function RegisterPage() {
+  const [infoUser, setInfoUser] = useState({
+    username: "",
+    email: "",
+    password: "",
+  });
+
+  // gather all credentials user
+  const onInputChange = (event) => {
+    const { name, value } = event.target;
+    setInfoUser((prevInfoUser) => ({
+      ...prevInfoUser,
+      [name]: value,
+    }));
+  };
+
+  const handleSignUp = async (event) => {
+    event.preventDefault();
+
+    try {
+      const response = await authAPI.signUp(
+        infoUser.username,
+        infoUser.email,
+        infoUser.password
+      );
+      if (response) {
+        // will need to add redirection to dashboard
+        console.log("user logged in");
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <div className="min-h-screen">
       <section className="w-full h-screen flex">
         {/* Left column */}
         <aside className="lg:block hidden w-[25%] py-4 px-8 space-y-24 bg-lightGreen">
           <div className="flex justify-center gap-6">
-            <img src={circles} alt="" srcset="" />
+            <img src={circles} alt="" srcSet="" />
             <h2 className="leading-[1]">
               Task <br /> Zen
             </h2>
@@ -27,7 +62,7 @@ export default function RegisterPage() {
           </p>
 
           <div className="flex justify-center">
-            <img src={checklist} className="w-[70%]" alt="" srcset="" />
+            <img src={checklist} className="w-[70%]" alt="" srcSet="" />
           </div>
         </aside>
 
@@ -35,20 +70,48 @@ export default function RegisterPage() {
         <main className="w-full lg:w-[75%]  flex flex-col justify-around">
           <Logo />
 
-          <form action="" className="w-full px-6 lg:w-[30%] mx-auto">
-            <label className="" htmlFor="">
-              Username / Email:
+          <form
+            onSubmit={handleSignUp}
+            className="w-full px-6 lg:w-[30%] mx-auto"
+          >
+            <label className="" htmlFor="username">
+              Username:
             </label>
             <input
               className="w-full"
               type="text"
-              placeholder="enter username/email"
+              name="username"
+              id="username"
+              placeholder="enter username"
+              onChange={onInputChange}
+              required
+            />
+            <label className="" htmlFor="email">
+              Email:
+            </label>
+            <input
+              className="w-full"
+              type="text"
+              name="email"
+              id="email"
+              placeholder="enter email"
+              onChange={onInputChange}
+              required
             />
 
-            <label htmlFor="">Password:</label>
-            <input type="password" placeholder="enter password" />
+            <label htmlFor="password">Password:</label>
+            <input
+              type="password"
+              name="password"
+              id="password"
+              placeholder="enter password"
+              onChange={onInputChange}
+              required
+            />
 
-            <Button className="mt-10">Register</Button>
+            <Button className="mt-10" type="submit">
+              Register
+            </Button>
 
             <Link to="/">
               <Button className="mt-10" type="white">

--- a/frontend/src/services/authAPI.js
+++ b/frontend/src/services/authAPI.js
@@ -1,0 +1,29 @@
+const API_URL = process.env.REACT_APP_API_URL;
+// API_URL encouters a bug, it redirects to localhost3000 instead of 5000
+
+async function signUp(username, email, password) {
+  console.log("username, email, password", username, email, password);
+  const response = await fetch("http://localhost:5000/api/auth/signup", {
+    method: "POST",
+    body: JSON.stringify({ username, email, password }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  if (response.status === 201) {
+    const data = await response.json();
+    const token = data.token;
+    sessionStorage.setItem("token", token);
+    return true;
+  } else {
+    // Registration failed, handle errors
+    const errorData = await response.json(); // Parse the error JSON
+    console.log("error data", errorData);
+  }
+}
+
+const exportFunctions = {
+  signUp,
+};
+
+export default exportFunctions;


### PR DESCRIPTION
**This PR contains:**
- add the signup endpoint in the front end
- form on registration page gather now the user info
- api is called on submit button and user info send to the backend 

**To test:**
- pull down feat/create_user
- in backend folder, start server with command npm run dev
- in a second terminal, in the frontend folder, start server with command npm start
- got to localhost:3000/registration and fill some user information (there is currently no redirection after signup, we stay on the registration page)