### PR TITLE
fix handle name of the day on my task page

### DIFF
--- a/frontend/src/components/MyTasks/Task.jsx
+++ b/frontend/src/components/MyTasks/Task.jsx
@@ -15,7 +15,7 @@ export default function Task(props) {
   const checkboxesWeek = useMemo(() => {
     return dayWeek.map((day) => {
       if (
-        taskDays.includes(day[0].toLowerCase()) ||
+        taskDays.includes(day[0]) ||
         taskDays.includes(day[1])
 
         // taskDays.includes(day[1].toString())
@@ -85,12 +85,14 @@ export default function Task(props) {
     // get two first letters of days to compare them
     const daysAfterSlice = [];
 
-    if (isNaN(taskDays[0]))
+    if (isNaN(taskDays[0])) {
       taskDays.forEach((taskDay) => {
-        daysAfterSlice.push(taskDay.slice(0, 2));
+        return daysAfterSlice.push(taskDay.slice(0, 2).toLowerCase());
       });
+    }
 
     return dayMonth.map((day) => {
+      console.log("daysAfterSlice", daysAfterSlice);
       if (
         daysAfterSlice.includes(day[0].toLowerCase()) ||
         taskDays.includes(day[1])


### PR DESCRIPTION
**this PR contains**

It handles now the name of the day entered when creating a task.
![image](https://github.com/chingu-voyages/v47-tier3-team-27/assets/114222588/bda583d4-2f67-4b86-b434-0632702b98a4)
